### PR TITLE
Show title image filename on hover when picking icon.

### DIFF
--- a/templates/imagepicker.mustache
+++ b/templates/imagepicker.mustache
@@ -40,7 +40,7 @@
   <div class="row">
     {{#images}}
     <div class="col">
-      <div class="border p-3 tiny_elements_imagepicker"><img src="{{url}}" class="tiny_elements_thumbnail" alt="{{name}}"></div>
+      <div class="border p-3 tiny_elements_imagepicker"><img src="{{url}}" class="tiny_elements_thumbnail" alt="{{name}}" title="{{name}}"></div>
     </div>
     {{/images}}
   </div>


### PR DESCRIPTION
Unfortunately, alt="" texts are not shown upon hover.
title="" are.
It comes in handy if you browse for an icon. It's clear they are alphabetically sorted. But the title itself helps a lot.

Thanks!